### PR TITLE
Remove redundant taps

### DIFF
--- a/roles/homebrew/defaults/main.yml
+++ b/roles/homebrew/defaults/main.yml
@@ -3,7 +3,6 @@
 homebrew:
   taps:
     - caskroom/fonts
-    - homebrew/dupes
   formulas:
     - autoconf
     - automake
@@ -45,4 +44,3 @@ homebrew:
     - font-source-sans-pro
     - font-terminus
     - font-ubuntu
-

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -4,9 +4,23 @@
   homebrew:
     update_homebrew: yes
 
+- name: Create Caskroom directory
+  become: true
+  file:
+    path: /usr/local/Caskroom
+    state: directory
+    owner: "{{ ansible_user_id }}"
+    group: admin
+    mode: 0775
+
 - include: homebrew-taps.yml
 - include: homebrew-formulas.yml
 - include: homebrew-casks.yml
 - include: homebrew-fonts.yml
+
+- name:
+  homebrew:
+    name: grep
+    install_options: with-default-names
 
 # vim:set ft=ansible:

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -9,9 +9,4 @@
 - include: homebrew-casks.yml
 - include: homebrew-fonts.yml
 
-- name:
-  homebrew:
-    name: homebrew/dupes/grep
-    install_options: with-default-names
-
 # vim:set ft=ansible:

--- a/setup-laptop.yml
+++ b/setup-laptop.yml
@@ -19,9 +19,3 @@
     file:
       dest: "~/.ssh"
       state: directory
-  - name: Copy ProFont
-    copy:
-      src: "ProFont_r400-11.dfont"
-      dest: "~/Library/Fonts/"
-    tags:
-      - fonts


### PR DESCRIPTION
c.f: https://github.com/Homebrew/homebrew-dupes

Fixes this error:
```
TASK [homebrew : Install Homebrew Taps] ****************************************************************************************************************************************
changed: [172.16.2.87] => (item=caskroom/fonts)
failed: [172.16.2.87] (item=homebrew/dupes) => {"changed": false, "item": "homebrew/dupes", "msg": "added: 0, unchanged: 0, error: failed to tap: homebrew/dupes"}
```